### PR TITLE
Support fileName being an absolute path

### DIFF
--- a/__tests__/.test-dotenv
+++ b/__tests__/.test-dotenv
@@ -1,0 +1,1 @@
+TEST_VAR="value"

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -1,5 +1,6 @@
 'use strict';
 const expect = require('chai').expect;
+const path = require('path');
 const env = require('../index.js');
 
 beforeEach(function() {
@@ -57,6 +58,27 @@ describe('SOURCEABLE .env file', function() {
   
   it('returns correct variables', function() {
     const resultingEnv = env('.env.sh');
+    
+    expect(resultingEnv).to.eql(expectedMap);
+  });
+});
+
+describe('SOURCEABLE .env absolute path', function() {
+  const expectedMap = {
+    TEST_VAR: 'value',
+  };
+  const expectedEnv = {
+    TEST_VAR: 'value',
+  };
+  
+  it('sets the environment', function() {
+    const resultingEnv = env(path.join(__dirname, '.test-dotenv'));
+    
+    expect(process.env.TEST_VAR).to.equal(expectedEnv.TEST_VAR);
+  });
+  
+  it('returns correct variables', function() {
+    const resultingEnv = env(path.join(__dirname, '.test-dotenv'));
     
     expect(resultingEnv).to.eql(expectedMap);
   });

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var fs = require('fs');
 module.exports = function(fileName) {
   if(!fileName) fileName = '.env';
   
-  var filePath = path.join(process.cwd(), fileName);
+  var filePath = path.isAbsolute(fileName) ? fileName : path.join(process.cwd(), fileName);
   var fileContents = fs.readFileSync(filePath, {encoding: 'utf-8'});
   
   let env = {};


### PR DESCRIPTION
Use case being running a command from a subdirectory of a project, but wanting to ensure we resolve the project root `.env` file.

E.g.

```
require('source-dot-env')(path.join(__dirname, '..', '..', '.env');
```